### PR TITLE
[BUGFIX] Fix typos in German bylaws document

### DIFF
--- a/Documentation/Association/BylawsAndProceedingsGermanOriginal.rst
+++ b/Documentation/Association/BylawsAndProceedingsGermanOriginal.rst
@@ -128,9 +128,9 @@ B. Vereinsvorstand (Board)
 
 C. Rechnungsrevisoren
 
-D. Geschäftsprüfungskommission (Business Control Comittee)
+D. Geschäftsprüfungskommission (Business Control Committee)
 
-E. Ausschüsse (Comittees)
+E. Ausschüsse (Committees)
 
 ..  _bylaws-de-a:
 
@@ -175,15 +175,19 @@ Die Aufgaben und Kompetenzen der Generalversammlung sind Folgende:
 #. Kenntnisnahme des Budgets für das laufende Jahr;
 #. Aufnahmebeitrag und Jahresbeitrag der Mitglieder für das laufende Mitgliedsjahr;
 #. Wahlen
+
     #. des Sachverständigenrats des Vorstandes
     #. der Rechnungsrevisoren
     #. der Mitglieder der Geschäftsprüfungskommission
+
 #. Behandlung von Anträgen
+
     #. des Vereinsvorstands
     #. der Mitglieder
+
 #. Tätigkeitsprogramm;
-#. #. Statutenänderungen;
-Ernennung von Ehrenmitgliedern;
+#. Statutenänderungen;
+#. Ernennung von Ehrenmitgliedern;
 #. Beschwerde gegen geschäftsführende Organe, Beschlussfassung über die Berufung gegen einen Ausschliessungsbeschluss oder Ablehnung eines vorläufigen Aufnahmebeschlusses des Vereinsvorstands.
 
 ..  _bylaws-de-14:
@@ -329,9 +333,9 @@ Die Generalversammlung wählt jeweils auf eine Amtsdauer von einem Jahr eine ane
 
 Die Revisionsstelle prüft die Buchführung und erstattet der Generalversammlung schriftlich Bericht und stellt der Generalversammlung Antrag auf Erteilung oder Verweigerung der Décharge gegenüber dem Kassier und dem Vorstand.
 
-..  _bylaws-de-e:
+..  _bylaws-de-d:
 
-E Geschäftsprüfungskommission
+D Geschäftsprüfungskommission
 =============================
 
 ..  _bylaws-de-26:


### PR DESCRIPTION
## Summary

Fix broken list, section labels, and typos in `Documentation/Association/BylawsAndProceedingsGermanOriginal.rst`:

- **Art. 13**: repair malformed enumerated list (orphaned items)
- Restore section **D (Geschäftsprüfungskommission)**, which was a duplicate of E
- Fix duplicate `_bylaws-de-e` anchor (→ `_bylaws-de-d`)
- Typo: *Comittee* → *Committee* in Art. 9

## Test plan

- [ ] Rendered output shows Art. 13 as a properly nested enumerated list
- [ ] Section D heading reads "D Geschäftsprüfungskommission" and resolves via `_bylaws-de-d`
- [ ] No duplicate anchors remain in the document