### PR TITLE
[TASK] Implement T3A Board policy for policy+bylaw change approvals

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,21 @@
+# This CODEOWNERS file is governed by a TYPO3 Association Board
+# decision, documented in Documentation/Association/Board/Decisions/2026/07-09-PolicyGovernance.rst.
+# Changing it (apart from maintenance changes) requires a formal Board
+# decision, documented in the same manner.
+
+# Documents in the Documentation/Association/ directory are owned by
+# the TYPO3 Association Board. Maintenance changes to these require
+# approval by a Board member, and content changes require a formal
+# Board decision.
+Documentation/Association/ @TYPO3-Documentation/board
+Documentation/Community/ @TYPO3-Documentation/board
+Documentation/Product/ @TYPO3-Documentation/board
+Documentation/Project/ @TYPO3-Documentation/board
+
+# TODO: There is no "BCC" group in the TYPO3-Documentation
+# organization, yet
+# Documentation/Association/BudgetOwnersGuide.rst @TYPO3-Documentation/bcc
+
+# Changes to the approval workflows require a Board decision, as well
+.github/CODEOWNERS @TYPO3-Documentation/board
+.github/workflows/check-.* @TYPO3-Documentation/board

--- a/.github/workflows/check-approvals.yml
+++ b/.github/workflows/check-approvals.yml
@@ -1,0 +1,92 @@
+# This GitHub workflow asserts that each pull request has the required
+# number of approvals based on its change type label.
+#
+# Rules are as follows:
+# - "type: bylaw change" requires 2 approvals (in addition to a link
+#   to the relevant GA protocol, which is enforced by a different
+#   workflow)
+# - "type: formal change" requires 2 approvals
+# - "type: maintenance change" requires 1 approval
+#
+# Unfortunately, GitHub does not allow us to enforce this through
+# branch protection rules, so it must be implemented through a custom
+# workflow.
+#
+# This workflow is governed by a TYPO3 Association Board decision,
+# documented in Documentation/Association/Board/Decisions/2026/07-09-PolicyGovernance.rst.
+# Changing it (apart from maintenance changes) requires a formal Board
+# decision, documented in the same manner.
+name: Check approvals
+
+# Runs as pull_request_target / pull_request_review so it has a write token and can
+# read reviews on fork PRs.
+#
+# SECURITY: never check out or execute PR-provided code here, and never interpolate
+# PR-controlled text into a shell. Inspect the PR only through the API.
+on:
+  pull_request_target:
+    branches:
+      - main
+    types: [opened, reopened, synchronize, labeled, unlabeled]
+  pull_request_review:
+    types: [submitted, dismissed, edited]
+
+jobs:
+  check-approvals:
+    name: Assert required approvals
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      checks: write
+    steps:
+      - name: Count approvals and publish a status check
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const requiredByLabel = {
+              'type: bylaw change': 2,
+              'type: formal change': 2,
+              'type: maintenance change': 1,
+            };
+            const pr = context.payload.pull_request;
+
+            // Required number of approvals is driven by the change type label.
+            const labels = await github.paginate(github.rest.issues.listLabelsOnIssue, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr.number,
+            });
+            const required = Math.max(
+              0,
+              ...labels.map(l => requiredByLabel[l.name] || 0),
+            );
+
+            // Count distinct users whose latest review is an approval.
+            const reviews = await github.paginate(github.rest.pulls.listReviews, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pr.number,
+            });
+            const latestState = new Map();
+            for (const r of reviews) {
+              if (!r.user || r.state === 'COMMENTED') continue;
+              latestState.set(r.user.login, r.state);
+            }
+            const count = [...latestState.values()].filter(s => s === 'APPROVED').length;
+
+            const ok = count >= required;
+            await github.rest.checks.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              name: 'Required approvals',
+              head_sha: pr.head.sha,
+              status: 'completed',
+              conclusion: ok ? 'success' : 'failure',
+              output: {
+                title: `${count} / ${required} approvals`,
+                summary: ok
+                  ? `${count} of ${required} required approval(s) present.`
+                  : `This pull request needs ${required} approval(s) but only has ${count}.`,
+              },
+            });

--- a/.github/workflows/check-bylaw-change.yml
+++ b/.github/workflows/check-bylaw-change.yml
@@ -1,0 +1,153 @@
+# This GitHub workflow asserts that pull requests that modify the
+# bylaws include a link to the relevant General Assembly protocol in
+# a Git commit message. Every single commit that touches the bylaws
+# file must carry such a link. This is required because any changes to
+# the bylaws require a two-thirds majority vote of the General Assembly,
+# and the protocol serves as proof of that vote.
+#
+# This workflow is governed by a TYPO3 Association Board decision,
+# documented in Documentation/Association/Board/Decisions/2026/07-09-PolicyGovernance.rst.
+# Changing it (apart from maintenance changes) requires a formal Board
+# decision, documented in the same manner.
+name: Bylaw change
+
+# Runs as pull_request_target so it has a write token for fork PRs (labels/comments).
+#
+# SECURITY: never check out or execute PR-provided code here, and never interpolate
+# PR-controlled text into a shell. Inspect the PR only through the API (as below).
+on:
+  pull_request_target:
+    branches:
+      - main
+    types: [opened, reopened, synchronize, labeled, unlabeled]
+
+jobs:
+  check-protocol-link:
+    name: Assert that General Assembly protocol is linked
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Check for a protocol link and update the pull request
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const bylawsFile = 'Documentation/Association/BylawsAndProceedings.rst';
+            const protocolLink = /https:\/\/typo3\.org\S*/;
+
+            const commits = await github.paginate(github.rest.pulls.listCommits, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+            });
+            const labels = await github.paginate(github.rest.issues.listLabelsOnIssue, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+
+            // If this item was manually flagged as a maintenance change (bylaws can
+            // have typos, too), we don't require a protocol link.
+            const explicitlyDeclaredAsMaintenance = labels.some(l => l.name === 'type: maintenance change');
+
+            // Every commit that touches the bylaws file must carry a link to the
+            // General Assembly protocol in its message. We inspect each commit's
+            // files individually so a single linked commit cannot vouch for
+            // unrelated bylaw changes elsewhere in the PR.
+            const bylawCommits = [];
+            for (const c of commits) {
+              const detail = await github.rest.repos.getCommit({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                ref: c.sha,
+              });
+              const touchesBylaws = (detail.data.files || [])
+                .some(f => f.filename === bylawsFile);
+              if (!touchesBylaws) {
+                continue;
+              }
+              bylawCommits.push({
+                sha: c.sha.substring(0, 7),
+                url: (c.commit.message.match(protocolLink) || [])[0] || null,
+              });
+            }
+
+            if (bylawCommits.length === 0) {
+              return;
+            }
+
+            const found = bylawCommits.every(c => c.url);
+
+            const marker = '<!-- ga-protocol-check -->';
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const existing = comments.find(c => c.body.includes(marker));
+
+            const intro = `This pull request modifies the TYPO3 Association bylaws. Any changes to the bylaws require a two-thirds majority vote of the General Assembly. To ensure that this pull request is valid, every commit that touches the bylaws must include a link to the General Assembly protocol in its Git commit message.`;
+            const note = `**Note to reviewer**: If you are approving this pull request, please make sure that the changes in this PR match the changes that were approved in the General Assembly protocol. Also make sure that the non-authoritative English translation of the bylaws is updated accordingly.\n\nIn addition to the General Assembly protocol, this pull request must be approved by at least two representatives of the document owner (in this case, the TYPO3 Association Board in representation for the General Assembly).`;
+            const commitList = bylawCommits
+              .map(c => c.url
+                ? `- ✅ ${c.sha} → ${c.url}`
+                : `- ❌ ${c.sha} → no General Assembly protocol link`)
+              .join('\n');
+            const summary = found
+              ? `Every commit that modifies the bylaws links to the General Assembly protocol.`
+              : `Some commits that modify the bylaws are missing a link to the General Assembly protocol.`;
+            let body = `${marker}\n${intro}\n\n${summary}\n\n${commitList}\n\n${note}`;
+
+            if (explicitlyDeclaredAsMaintenance) {
+              body = `${marker}\nThis pull request modifies the TYPO3 Association bylaws, but was explicitly declared as a maintenance change.\n\n**Note to reviewer**: If you are approving this pull request, please make sure that this change *DOES NOT* affect the substantive content of the bylaws.`;
+            }
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }
+
+            if (explicitlyDeclaredAsMaintenance) {
+              return;
+            }
+
+            const addLabel = found ? 'bylaw-change: ga-approved' : 'bylaw-change: ga-approval needed';
+            const removeLabel = found ? 'bylaw-change: ga-approval needed' : 'bylaw-change: ga-approved';
+
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              labels: [addLabel],
+            });
+
+            try {
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                name: removeLabel,
+              });
+            } catch (err) {
+              // A 404 just means the label wasn't set on the PR — nothing to remove.
+              if (err.status !== 404) {
+                throw err;
+              }
+            }
+
+            if (!found) {
+              const missing = bylawCommits.filter(c => !c.url).map(c => c.sha).join(', ');
+              core.setFailed(`Commits modifying the bylaws without a General Assembly protocol link: ${missing}`);
+            }

--- a/.github/workflows/check-change-type.yml
+++ b/.github/workflows/check-change-type.yml
@@ -1,0 +1,210 @@
+# This GitHub workflow asserts that every pull request is classified
+# as either a bylaw change, a formal change, or a maintenance change.
+# This classification is required because each change type has
+# different approval requirements, which are enforced by a separate
+# workflow.
+#
+# This workflow is governed by a TYPO3 Association Board decision,
+# documented in Documentation/Association/Board/Decisions/2026/07-09-PolicyGovernance.rst.
+# Changing it (apart from maintenance changes) requires a formal Board
+# decision, documented in the same manner.
+name: Check change type
+
+# Runs as pull_request_target so it has a write token for fork PRs (labels/comments).
+# SECURITY: never check out or execute PR-provided code here, and never interpolate
+# PR-controlled text into a shell. Inspect the PR only through the API (as below).
+on:
+  pull_request_target:
+    branches:
+      - main
+    types: [opened, reopened, synchronize, labeled, unlabeled]
+
+jobs:
+  check-change-type:
+    name: Assert that a change type label is set
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Determine and enforce the change type label
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const bylawFile = 'Documentation/Association/BylawsAndProceedings.rst';
+            const bylawLabel = 'type: bylaw change';
+            const acceptedLabels = ['type: formal change', 'type: maintenance change'];
+            const marker = '<!-- change-type-check -->';
+            const requiredByLabel = {
+              'type: bylaw change': 2,
+              'type: formal change': 2,
+              'type: maintenance change': 1,
+            };
+
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+            });
+
+            // Bylaw changes are categorized automatically.
+            const touchesBylaws = files.some(f => f.filename === bylawFile);
+            if (touchesBylaws) {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                labels: [bylawLabel],
+              });
+            }
+
+            // Any other change must be labeled as formal or maintenance.
+            const labels = await github.paginate(github.rest.issues.listLabelsOnIssue, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const labelNames = labels.map(l => l.name);
+            const classifiedAs = touchesBylaws
+              ? bylawLabel
+              : acceptedLabels.find(l => labelNames.includes(l));
+
+            // Locate an existing comment so it can be updated in place.
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const existing = comments.find(c => c.body.includes(marker));
+
+            // Classified: resolve a previously posted comment, otherwise stay silent.
+            if (classifiedAs) {
+              if (existing) {
+                await github.rest.issues.updateComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: existing.id,
+                  body: `${marker}\n✅ This pull request is classified as \`${classifiedAs}\`.\n\nIt requires **${requiredByLabel[classifiedAs]} approvals** by representatives of the document owner (TYPO3 Association Board if not stated otherwise).`,
+                });
+              }
+              return;
+            }
+
+            // Not classified: ask for a label (idempotent) and fail.
+            const options = acceptedLabels.map(l => '`' + l + '`').join(' or ');
+            const body = `${marker}\nThis pull request must be classified as either a bylaw change, a formal change, or a maintenance change. Please add one of the following labels: ${options}.`;
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }
+
+            core.setFailed(`Missing a change type label. Add one of: ${acceptedLabels.join(', ')}.`);
+
+  check-formal-decision:
+    name: Assert that a formal change records a decision
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Require a new decision record for formal changes
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const decisionsDir = 'Documentation/Association/Board/Decisions/';
+            const formalLabel = 'type: formal change';
+            const pendingLabel = 'pending formal decision';
+            const presentLabel = 'formal decision present';
+            const marker = '<!-- formal-decision-check -->';
+
+            const removeLabel = async (name) => {
+              try {
+                await github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: context.issue.number,
+                  name,
+                });
+              } catch (err) {
+                // A 404 just means the label wasn't set on the PR — nothing to remove.
+                if (err.status !== 404) {
+                  throw err;
+                }
+              }
+            };
+
+            // This check only applies to formal changes. If the PR is no longer a
+            // formal change, clean up any decision labels this job may have added.
+            const labels = await github.paginate(github.rest.issues.listLabelsOnIssue, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            if (!labels.some(l => l.name === formalLabel)) {
+              await removeLabel(pendingLabel);
+              await removeLabel(presentLabel);
+              return;
+            }
+
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+            });
+            const newDecision = files.find(
+              f => f.status === 'added'
+                && f.filename.startsWith(decisionsDir)
+                && !f.filename.split('/').pop().startsWith('.'),
+            );
+            const hasNewDecision = newDecision !== undefined;
+
+            const intro = `This pull request is classified as a formal change. This means it needs an formally documented decision by the TYPO3 Association Board, which must be documented in a new file under \`${decisionsDir}\`.`;
+            const body = hasNewDecision
+              ? `${marker}\n${intro}\n\n✅ New decision record found at \`${newDecision.filename}\`.`
+              : `${marker}\n${intro}\n\n❌ A formal change must add a new decision record under \`${decisionsDir}\`.`;
+
+            // Idempotent comment: edit the existing one in place if present.
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const existing = comments.find(c => c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }
+
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              labels: [hasNewDecision ? presentLabel : pendingLabel],
+            });
+            await removeLabel(hasNewDecision ? pendingLabel : presentLabel);
+
+            if (!hasNewDecision) {
+              core.setFailed(`A "${formalLabel}" pull request must add a new decision record under ${decisionsDir}.`);
+            }

--- a/.github/workflows/test-documentation.yml
+++ b/.github/workflows/test-documentation.yml
@@ -1,10 +1,10 @@
-name: test documentation
+name: Test documentation
 
 on: [ push, pull_request ]
 
 jobs:
   tests:
-    name: documentation
+    name: Documentation build
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,25 +1,97 @@
-# Contribute to TYPO3 Documentation
+# Contributing to the TYPO3 Association Policy Repository
 
-## Create Issues
+This repository governs the TYPO3 Association's policies and bylaws, and the
+changes made to them. All changes are tracked using Git and GitHub pull
+requests.
 
-* If you find something missing or something is wrong in this manual, you are welcome to write an issue describing the problem. 
-* If you can, please try to fix the problem yourself. 
-* For minor changes, it is not necessary to create an issue first. 
+This process is governed by a TYPO3 Association Board decision, documented in
+[`Documentation/Association/Board/Decisions/2026/07-09-PolicyGovernance.rst`](Documentation/Association/Board/Decisions/2026/07-09-PolicyGovernance.rst).
 
-## Make changes (create pull requests)
+## Ownership
 
-* In order to make changes on a [rendered page](https://docs.typo3.org/typo3cms/TCAReference/), just click on "Edit me on GitHub".
-* For a step-by-step walkthrough for making a change, see [Contribute to docs.typo3.org](https://docs.typo3.org/typo3cms/HowToDocument/WritingDocsOfficial/Index.html)
-* For a step-by-step walkthrough of alternative workflow, see [Local Editing and Rendering with Docker](https://docs.typo3.org/typo3cms/HowToDocument/WritingDocsOfficial/LocalEditing.html)
+Every policy document specifies an **owner** on the line just below its H1
+title. The owner is who can authorize changes to that document — for example:
 
-## Get help
+> This policy can only be changed through a decision by: TYPO3 Association
+> General Assembly.
 
-* If you need help with contributing to the docs, see [How to get Help](https://docs.typo3.org/typo3cms/HowToDocument/HowToGetHelp.html)
+Decisions about ownership itself are made by the TYPO3 Association Board. The
+TYPO3 Association General Assembly can be represented by members of the TYPO3
+Association Board.
 
-# Contribute to TYPO3 Core
+## Types of changes
 
-* See [TYPO3 Contribution Guide - Core Development](https://docs.typo3.org/typo3cms/ContributionWorkflowGuide/)
+Every pull request must be handled as **one, and only one,** of the following
+change types. No files can be changed unless the pull request is classified
+correctly. This classification is enforced automatically and is reflected in a
+label on the pull request.
 
-# General TYPO3 Support
+### Maintenance changes
 
-If you have some general TYPO3 support questions or need help with TYPO3, please see https://typo3.org/help.
+Changes that **do not** change the meaning of the text — for example,
+correcting a link that leads to a 404 page, or fixing a typo.
+
+- Label: `type: maintenance change`
+- Requires **1 approval** by a representative of the owner.
+- The decision can be documented in the commit message; no separate decision
+  document is required.
+
+### Formal changes
+
+Changes **to the meaning** of the text. These require a formal decision by the
+owner, in accordance with the owner's decision-making rules.
+
+- Label: `type: formal change`
+- Requires **2 approvals** by representatives of the owner.
+- Must include a **separate decision document** in the pull request,
+  conforming to the owner's decision-documentation rules. For example, a TYPO3
+  Association Board decision to change the Reimbursement Regulations is added as
+  a new file under
+  [`Documentation/Association/Board/Decisions/`](Documentation/Association/Board/Decisions/).
+
+### Bylaw changes
+
+Any change to the bylaws
+([`Documentation/Association/BylawsAndProceedings.rst`](Documentation/Association/BylawsAndProceedings.rst))
+is a special kind of formal change. Each change to the bylaws must be
+substantiated by a two-thirds majority vote of the General Assembly.
+
+- Label: `type: bylaw change` (applied automatically when the bylaws file is
+  touched).
+- Requires **2 approvals** by representatives of the owner.
+- **Every commit** that touches the bylaws file must include a link to the
+  relevant General Assembly protocol (a `https://typo3.org/...` URL) in its Git
+  commit message. The protocol serves as proof of the required vote, and a pull
+  request is only merged if such a protocol recorded the vote for the change.
+- When approving, make sure the changes match those approved in the General
+  Assembly protocol, and that the non-authoritative English translation of the
+  bylaws is updated accordingly.
+
+## Documenting decisions
+
+All changes must be merged as pull requests that document the decision
+authorizing the change:
+
+- **Maintenance changes** — documented in the commit message.
+- **Formal changes** — documented in a separate decision document included in
+  the pull request.
+- **Bylaw changes** — substantiated by a linked General Assembly protocol.
+
+## How this is enforced
+
+Because GitHub branch protection rules cannot express these requirements, they
+are enforced through GitHub Actions workflows in
+[`.github/workflows/`](.github/workflows/):
+
+- **Check change type** — asserts that every pull request carries exactly one
+  change-type label, automatically labels bylaw changes, and requires formal
+  changes to add a new decision record under
+  `Documentation/Association/Board/Decisions/`.
+- **Check approvals** — asserts that the pull request has the number of
+  approvals required by its change-type label (1 for maintenance, 2 for formal
+  and bylaw changes).
+- **Bylaw change** — asserts that every commit touching the bylaws links to the
+  relevant General Assembly protocol.
+
+Changing these workflows (apart from maintenance changes) requires a formal
+Board decision, documented in the same manner.

--- a/Documentation/Association/Board/Decisions.rst
+++ b/Documentation/Association/Board/Decisions.rst
@@ -1,0 +1,13 @@
+:navigation-title: Decision log
+..  include:: /Includes.rst.txt
+..  _t3a-board-decisions:
+
+====================================
+TYPO3 Association Decision directory
+====================================
+
+..  toctree::
+    :titlesonly:
+    :glob:
+
+    Decisions/*

--- a/Documentation/Association/Board/Decisions/2025/.template.rst
+++ b/Documentation/Association/Board/Decisions/2025/.template.rst
@@ -1,0 +1,78 @@
+:navigation-title: MM-DD <DECISION TITLE>
+..  include:: /Includes.rst.txt
+..  _t3a-board-decision-YYYY-MM-DD-<DECISION SLUG>:
+
+================================
+Board Decision: <DECISION TITLE>
+================================
+
+:Start of voting: 8 June 2026
+:Voting deadline: 10 June 2026
+:Decision owner: `<DECISION OWNER>`_
+:Decision status: <✅ Accepted | ❌ Rejected>
+
+Attendance and voting
+=====================
+
+====================  ============  ==========
+Board Member          Attendance    Vote
+====================  ============  ==========
+`Olivier Dobberkau`_  In meeting    <✅ Yes | ❌ No | ⚪ Abstain | ⚫ Recused>
+`Stefan Busemann`_    In meeting    <✅ Yes | ❌ No | ⚪ Abstain | ⚫ Recused>
+`Boris Hinzer`_       In meeting    <✅ Yes | ❌ No | ⚪ Abstain | ⚫ Recused>
+`Rachel Foucard`_     In meeting    <✅ Yes | ❌ No | ⚪ Abstain | ⚫ Recused>
+`Martin Helmich`_     In meeting    <✅ Yes | ❌ No | ⚪ Abstain | ⚫ Recused>
+`Jana Höffner`_       In meeting    <✅ Yes | ❌ No | ⚪ Abstain | ⚫ Recused>
+`Thomas Maroschik`_   In meeting    <✅ Yes | ❌ No | ⚪ Abstain | ⚫ Recused>
+====================  ============  ==========
+
+.. _Olivier Dobberkau: https://my.typo3.org/u/oli4
+.. _Stefan Busemann: https://my.typo3.org/u/stefan.busemann
+.. _Martin Helmich: https://my.typo3.org/u/mhelmich
+.. _Jana Höffner: https://my.typo3.org/u/janahh
+.. _Thomas Maroschik: https://my.typo3.org/u/tmaroschik
+.. _Rachel Foucard: https://my.typo3.org/u/rakel
+.. _Boris Hinzer: https://my.typo3.org/u/web-vision
+
+Decision description
+====================
+
+Facts/Problem
+-------------
+
+...
+
+Objective
+---------
+
+...
+
+Obligations to cooperate
+------------------------
+
+...
+
+Financial and human resources impacts
+-------------------------------------
+
+...
+
+Resolution/Petitum
+------------------
+
+...
+
+Discarded alternatives
+----------------------
+
+...
+
+Attachments
+-----------
+
+...
+
+Comments
+--------
+
+...

--- a/Documentation/Association/Board/Decisions/2026.rst
+++ b/Documentation/Association/Board/Decisions/2026.rst
@@ -1,0 +1,13 @@
+:navigation-title: 2026
+..  include:: /Includes.rst.txt
+..  _t3a-board-decisions-2026:
+
+=========================================
+TYPO3 Association Decision directory 2026
+=========================================
+
+..  toctree::
+    :titlesonly:
+    :glob:
+
+    2026/*

--- a/Documentation/Association/Board/Decisions/2026/.template.rst
+++ b/Documentation/Association/Board/Decisions/2026/.template.rst
@@ -1,0 +1,76 @@
+:navigation-title: MM-DD <DECISION TITLE>
+..  include:: /Includes.rst.txt
+..  _t3a-board-decision-YYYY-MM-DD-<DECISION SLUG>:
+
+================================
+Board Decision: <DECISION TITLE>
+================================
+
+:Start of voting: 8 June 2026
+:Voting deadline: 10 June 2026
+:Decision owner: `<DECISION OWNER>`_
+:Decision status: <✅ Accepted | ❌ Rejected>
+
+Attendance and voting
+=====================
+
+====================  ==========  ======
+Board Member          Attendance  Vote
+====================  ==========  ======
+`Olivier Dobberkau`_  In meeting  <✅ Yes | ❌ No | ⚪ Abstain | ⚫ Recused>
+`Stefan Busemann`_    In meeting  <✅ Yes | ❌ No | ⚪ Abstain | ⚫ Recused>
+`Jochen Weiland`_     In meeting  <✅ Yes | ❌ No | ⚪ Abstain | ⚫ Recused>
+`Martin Helmich`_     In meeting  <✅ Yes | ❌ No | ⚪ Abstain | ⚫ Recused>
+`Jana Höffner`_       In meeting  <✅ Yes | ❌ No | ⚪ Abstain | ⚫ Recused>
+`Thomas Maroschik`_   In meeting  <✅ Yes | ❌ No | ⚪ Abstain | ⚫ Recused>
+====================  ==========  ======
+
+.. _Olivier Dobberkau: https://my.typo3.org/u/oli4
+.. _Stefan Busemann: https://my.typo3.org/u/stefan.busemann
+.. _Jochen Weiland: https://my.typo3.org/u/jweiland
+.. _Martin Helmich: https://my.typo3.org/u/mhelmich
+.. _Jana Höffner: https://my.typo3.org/u/janahh
+.. _Thomas Maroschik: https://my.typo3.org/u/tmaroschik
+
+Decision description
+====================
+
+Facts/Problem
+-------------
+
+...
+
+Objective
+---------
+
+...
+
+Obligations to cooperate
+------------------------
+
+...
+
+Financial and human resources impacts
+-------------------------------------
+
+...
+
+Resolution/Petitum
+------------------
+
+...
+
+Discarded alternatives
+----------------------
+
+...
+
+Attachments
+-----------
+
+...
+
+Comments
+--------
+
+...

--- a/Documentation/Association/Board/Decisions/2026/04-15-MeetingMinutes.rst
+++ b/Documentation/Association/Board/Decisions/2026/04-15-MeetingMinutes.rst
@@ -1,0 +1,90 @@
+:navigation-title: 04-15 Public meeting minutes & decisions
+..  include:: /Includes.rst.txt
+..  _t3a-board-decision-2026-04-15-publish-board-meeting-minutes-and-decisions:
+
+================================
+Board Decision: Publish Board meeting minutes and decisions
+================================
+
+:Start of voting: 15 April 2026
+:Voting deadline: 29 April 2026
+:Decision owner: `Martin Helmich`_
+:Decision status: ✅ Accepted
+
+Attendance and voting
+=====================
+
+====================  ============  ==========
+Board Member          Attendance    Vote
+====================  ============  ==========
+`Olivier Dobberkau`_  Asynchronous  ✅ Yes
+`Stefan Busemann`_    In meeting    ✅ Yes
+`Boris Hinzer`_       Not attended  ⚪ Abstain
+`Rachel Foucard`_     In meeting    ✅ Yes
+`Martin Helmich`_     Asynchronous  ✅ Yes
+`Jana Höffner`_       In meeting    ✅ Yes
+`Thomas Maroschik`_   Asynchronous  ✅ Yes
+====================  ============  ==========
+
+.. _Olivier Dobberkau: https://my.typo3.org/u/oli4
+.. _Stefan Busemann: https://typo3.org/team/board/stefan-busemann/
+.. _Jochen Weiland: https://my.typo3.org/u/jweiland
+.. _Martin Helmich: https://my.typo3.org/u/mhelmich
+.. _Jana Höffner: https://my.typo3.org/u/janahh
+.. _Thomas Maroschik: https://my.typo3.org/u/tmaroschik
+.. _Rachel Foucard: https://my.typo3.org/u/rakel
+.. _Boris Hinzer: https://my.typo3.org/u/web-vision
+
+Decision description
+====================
+
+Facts/Problem
+-------------
+
+Currently, the work of the TYPO3 Association Board is not particularly transparent. The only public communication are the Board reports that are (as of recently) published in intervals of 3 to 6 months and are oftentimes quite abstract.
+
+This frequently causes friction in the community, with the work of the Board giving off top-down/”ivory tower” vibes.
+
+Furthermore, the :ref:`rules of procedure <t3a-board-procedure>` already state that meeting minutes should be “made available online”.
+
+
+Objective
+---------
+
+- Having public meeting minutes and decision papers fosters transparency, by seeing community members what we are actually working on. Having decision papers published also increases accountability.
+- Constraint: Board meetings need to remain a safe space to discuss confidential and non-public information.
+
+
+Obligations to cooperate
+------------------------
+
+- TYPO3 Association Board (the proposed workflow requires two Board members to create and greenlight the public meeting minutes)
+- Content Group (the proposed workflow relies on the Content Group for the publication workflow)
+- TYPO3 Company (for required features on news.typo3.com, to make publication work without putting the minutes on the center of the home page)
+
+Financial and human resources impacts
+-------------------------------------
+
+- Increase of workload for the Secretary and the Content Group. Might be mitigated by offloading part of the copyediting to appropriately prompted AI models.
+
+Resolution/Petitum
+------------------
+
+- Implement confidentiality classification for meeting items and decision papers
+- Publish (appropriately edited and curated versions of) Board meeting minutes as described in the attached concept paper (via news.typo3.com)
+- Publish Decision papers as described in the attached concept paper (via the policy repository)
+
+Discarded alternatives
+----------------------
+
+Other implementation alternatives are listed in the concept paper.
+
+Attachments
+-----------
+
+...
+
+Comments
+--------
+
+None

--- a/Documentation/Association/Board/Decisions/2026/07-09-PolicyGovernance.rst
+++ b/Documentation/Association/Board/Decisions/2026/07-09-PolicyGovernance.rst
@@ -1,0 +1,106 @@
+:navigation-title: 07-09 Policy Governance
+..  include:: /Includes.rst.txt
+..  _t3a-board-decision-2026-07-09-policy-governance:
+
+===============================================================================
+Board Decision: Governance and Change Management in the TYPO3 Policy Repository
+===============================================================================
+
+:Start of voting: 9 July 2026
+:Voting deadline: 16 July 2026
+:Decision owner: `Martin Helmich`_
+:Decision status: ✅ Accepted (provisionally)
+
+Attendance and voting
+=====================
+
+====================  ============  ======
+Board Member          Attendance     Vote
+====================  ============  ======
+`Olivier Dobberkau`_  Asynchronous  ✅ Yes
+`Stefan Busemann`_    Not attended  ⏳ Pending
+`Jochen Weiland`_     Asynchronous  ✅ Yes
+`Martin Helmich`_     Asynchronous  ✅ Yes
+`Jana Höffner`_       Asynchronous  ✅ Yes
+`Thomas Maroschik`_   Asynchronous  ✅ Yes
+====================  ============  ======
+
+.. _Olivier Dobberkau: https://my.typo3.org/u/oli4
+.. _Stefan Busemann: https://typo3.org/team/board/stefan-busemann/
+.. _Jochen Weiland: https://my.typo3.org/u/jweiland
+.. _Martin Helmich: https://my.typo3.org/u/mhelmich
+.. _Jana Höffner: https://my.typo3.org/u/janahh
+.. _Thomas Maroschik: https://my.typo3.org/u/tmaroschik
+
+Decision description
+====================
+
+Facts/Problem
+-------------
+
+In the course of the typo3.org relaunch, the TYPO3 Association bylaws and policies were moved to the https://github.com/TYPO3-Documentation/Policy git repository. However, no approval or change management policies exist for this repository.
+
+This is particularly critical as there are a number of policy and bylaw changes in the coming that may attract broad community interest.
+
+Objective
+---------
+
+This proposal aims to provide a clear change management process for TYPO3 Association policies and bylaws, happening in the public and giving broad opportunities for member participation.
+
+Obligations to cooperate
+------------------------
+
+- TYPO3 Documentation Team, as they own the policy repository
+- TYPO3 Association Board and Business Control Committee, as this change management process requires their active participation
+
+
+Financial and human resources impacts
+-------------------------------------
+
+None.
+
+Resolution/Petitum
+------------------
+
+The board resolves to adopt the workflow proposed in `Proposal for Governance and Change Management in the TYPO3 Policy Repository <https://docs.google.com/document/d/1ecjAK-25y22E3XhelGEPV6SRoQjW6pK82Y_pNIlWxKo/edit?tab=t.0#heading=h.v3rpbh68yy7d>`_.
+
+This workflow includes:
+
+- Using the https://github.com/TYPO3-Documentation/Policy repository to govern TYPO3 Association policies and bylaws, and the changes thereof.
+- Using Git and GitHub Pull Requests to track changes to these documents.
+
+Rules for Ownership and Changes
+
+- **Owner:**
+
+  - Decisions of ownership are handled by the TYPO3 Association Board. 
+  - All policy documents within the repository must specify an owner on line just below the H1 title. It must state who can make changes to it (i.e. “owner”). For example: “This policy can only be changed through a decision by: TYPO3 Association General Assembly.”
+  - The TYPO3 Association General Assembly can be represented by Members of the TYPO3 Association Board.
+
+- **Types of changes and approval:** Two types of changes are possible in the decision and review process. No changes can be made to the repository files unless they are handled correctly as one, and only one, of these change types:
+
+  - **Formal changes:** Changes to the meaning of the text. These require formal decisions by the owner in accordance with the owner's decision-making rules. Merging changes require 2 PR approvals by representatives of the owner.
+    
+    For changes to the Bylaws, this means that each change must be substantiated by a vote of the General Assembly. When changing the Bylaws via a PR, this PR must only be merged if there is a General Assembly protocol that recorded the required vote for this change.
+    
+  - **Maintenance changes:** Changes that do not change the meaning of the text. For example, correcting a link that is currently leading to a 404 page. These do not require formal decisions by the owner, but PRs must be approved by 1 representative of the owner.
+
+- **Documenting decisions:** All changes must be merged as PRs containing documentation of the decision authorizing the change.
+
+  - **Formal changes:** A separate decision document must be included in the PR. The document should conform to the owner's decision documentation rules. For example, a TYPO3 Association Board decision to change the Reimbursement Regulations can be placed in the Documentation/Association/Board/Decisions folder.
+  - **Maintenance changes:** These change decisions can be documented in the commit message.
+
+Discarded alternatives
+----------------------
+
+- Move policy and bylaws back into the typo3.org TYPO3 instance. Discarded because Git and GitHub provide better change tracking and governance possibilities.
+
+Attachments
+-----------
+
+None
+
+Comments
+--------
+
+None

--- a/Documentation/Association/Board/Index.rst
+++ b/Documentation/Association/Board/Index.rst
@@ -9,5 +9,6 @@ Rules and Policies for the Board of the TYPO3 Association
 ..  toctree::
     :titlesonly:
     :glob:
+    :maxdepth: 2
 
     *

--- a/Documentation/Association/Board/PublishingDecisions.rst
+++ b/Documentation/Association/Board/PublishingDecisions.rst
@@ -1,0 +1,36 @@
+:navigation-title: Publishing decisions
+..  include:: /Includes.rst.txt
+..  _t3a-board-publishing-decisions:
+
+===================================================
+Publishing Decisions of the TYPO3 Association Board
+===================================================
+
+:Document Owner: TYPO3 Association Secretary
+:Author: `Martin Helmich`_
+:Version: 1.0, 7 July 2026
+
+.. _Martin Helmich: https://my.typo3.org/u/mhelmich
+
+1. Publication location
+=======================
+
+All decisions of the TYPO3 Association Board are published as reStructured Text documents in the `Decision directory`_ of the TYPO3 Association Policy directory. The decision directory is structured by year, and each decision is published as a separate document.
+
+Document naming and location *MUST* follow the pattern `Documentation/Association/Board/Decisions/YYYY/MM-DD-<DECISION TITLE>.rst`.
+
+.. _Decision directory: /Documentation/Association/Board/Decisions/index.rst
+
+2. Publication workflow
+=======================
+
+Decision papers are published in the documentation repository as soon as the decision has been accepted or rejected by the Board. Templates for decision documents are available at `Documentation/Association/Board/Decisions/YYYY/.template.rst`.
+
+The decision paper must be added to the repository via a pull request, which must be approved by at least one other Board member. This is verified by the pull request approval workflow of the repository.
+
+3. Decision implementation
+==========================
+
+1. Decisions that result in a policy change should be implemented in the same pull request as the decision paper, if possible.
+
+2. An exception to the above are changes to the Bylaws, which require a vote by the General Assembly. In this case, the Bylaws change must be documented by a link to the General Assembly protocol in which the bylaws change was approved.

--- a/Documentation/Association/Board/PublishingMeetingMinutes.rst
+++ b/Documentation/Association/Board/PublishingMeetingMinutes.rst
@@ -1,0 +1,35 @@
+:navigation-title: Publishing meeting minutes
+..  include:: /Includes.rst.txt
+..  _t3a-board-publishing-meeting-minutes:
+
+=========================================================
+Publishing Meeting Minutes of the TYPO3 Association Board
+=========================================================
+
+:Document Owner: TYPO3 Association Secretary
+:Author: `Martin Helmich`_
+:Version: 1.0, 7 July 2026
+
+.. _Martin Helmich: https://my.typo3.org/u/mhelmich
+
+-----------------------
+1. Publication location
+-----------------------
+
+All meeting minutes of the TYPO3 Association Board are published as news records on typo3.org, to be displayed on https://typo3.org/association/structure/board/protocols.
+
+---------------------------------
+2. Confidentiality classification
+---------------------------------
+
+1. There are two versions of the meeting minutes: a) a full and unredacted version that is only accessible to Board members under their NDA, and b) a public version that is published on typo3.org. The public version is curated and edited to remove confidential information, while still providing transparency about the Board's work.
+
+2. Agenda items are individually classified as either "public" (default), "redacted" (for items that are not public but do not require full confidentiality), or "confidential" (for items that are highly sensitive and should not be disclosed). The classification is determined by the Board during the meeting.
+
+-----------------------
+3. Publication workflow
+-----------------------
+
+1. After each Board meeting, the Secretary prepares the meeting minutes, including the classification of agenda items. Both the full and the public versions are circulated to all Board members for review and approval.
+2. The usage of AI (using the TYPO3 Association's official accounts) is allowed for the preparation of meeting minutes (including, but not limited to automated transcripts and summaries, editing, and further processing for publication). However, the Secretary must ensure that the final version is accurate and complete.
+3. The public version of the meeting minutes is published on typo3.org after approval by the Board. The full version is stored in a secure location accessible only to Board members under their NDA. The publication happens in coordination with the `Content Group <https://typo3.community/contribute/teams-committees/marketing/content>`_.

--- a/Documentation/Association/BudgetOwnersGuide.rst
+++ b/Documentation/Association/BudgetOwnersGuide.rst
@@ -5,6 +5,8 @@
 Budget Owner’s Guide
 ====================
 
+:Document Owner: TYPO3 Association Business Control Committee
+
 ..  _budget-owner-introduction:
 
 As a budget owner, you are responsible for your budget:

--- a/Documentation/Association/BylawsAndProceedings.rst
+++ b/Documentation/Association/BylawsAndProceedings.rst
@@ -6,7 +6,10 @@
 By-Laws & Proceedings — Statutes of the TYPO3 Association
 =========================================================
 
-*Our new by-laws are accepted by the General Assembly 2025 and are in place since July 2025*
+:Document Owner: TYPO3 Association General Assembly
+:Valid since: July 2025
+
+.. Attention:: This is a non-authoritative English translation of the :ref:`original German statutes <bylaws-de>`. The original German version is the legally binding version. In case of any discrepancies, the German version shall prevail.
 
 ..  _bylaws-i:
 

--- a/Documentation/Association/BylawsAndProceedingsGermanOriginal.rst
+++ b/Documentation/Association/BylawsAndProceedingsGermanOriginal.rst
@@ -6,7 +6,8 @@
 Statuten der TYPO3 Association
 ==============================
 
-*Gültig seit Juli 2025*
+:Dokumenten-Inhaber: TYPO3 Association Generalversammlung
+:Gültig seit: Juli 2025
 
 ..  _bylaws-de-i:
 


### PR DESCRIPTION
This commit adds a combination of GitHub workflows that assert that pull requests made to this repository follow the policy for modifying TYPO3 Association policies and bylaws.

Added rules in detail:

1. PRs that attempt to modify the TYPO3 Association bylaws MUST...

    - be labeled with a "type: bylaw change" label
    - contain a link to the General Assembly protocol in which the respective bylaw change was approved

2. For all other PRs, an action enforces that a "type: ..." label must be added to the PR (manually) to allow for proper classification as a "formal change" or "maintenance change".

3. For formal changes, an workflow enforces that the change is accompanied by a documented decision of the document owner -- if not specified otherwise, typically a T3A Board decision paper, to be collected in `Documentation/Association/Board/Decisions/`.

4. For all changes, a workflow verifies that the PR is approved by the required number of representatives of the document owner (2 for bylaws and other formal changes, 1 for maintenance changes).

These policies are backed by a formal decision of the TYPO3 Association Board (which is itself attached to this PR; see `Documentation/Association/Board/Decisions/2026/07-09-PolicyGovernance.rst`) and themselves require a formal decision to change them.