### PR TITLE
[BUGFIX] Disable workflow running on PR review events

### DIFF
--- a/.github/workflows/check-approvals.yml
+++ b/.github/workflows/check-approvals.yml
@@ -28,8 +28,6 @@ on:
     branches:
       - main
     types: [opened, reopened, synchronize, labeled, unlabeled]
-  pull_request_review:
-    types: [submitted, dismissed, edited]
 
 jobs:
   check-approvals:


### PR DESCRIPTION
These don't work as intended, as they're not running with the required
write access tokens.
